### PR TITLE
fix using `fmt` to printf.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -156,7 +156,7 @@ func (engine *Engine) CheckMem() {
 	if !engine.initOptions.UseStorage {
 		log.Println("Check virtualMemory...")
 		vmem, _ := mem.VirtualMemory()
-		fmt.Printf("Total: %v, Free:%v, UsedPercent:%f%%\n", vmem.Total, vmem.Free, vmem.UsedPercent)
+		log.Printf("Total: %v, Free:%v, UsedPercent:%f%%\n", vmem.Total, vmem.Free, vmem.UsedPercent)
 		useMem := fmt.Sprintf("%.2f", vmem.UsedPercent)
 		if useMem == "99.99" {
 			engine.initOptions.UseStorage = true


### PR DESCRIPTION
## Using `log` to printf instead of `fmt`

### Description

Just a simple issue, the `engine.go` using `fmt.Printf` to print info, that comes console while using self project, using `log.Printf` instead, in order to hook log message by self logger if needed.