### PR TITLE
Fix #37

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -20,6 +20,7 @@ Package riot is riot engine
 package riot
 
 import (
+	"encoding/binary"
 	"fmt"
 	"log"
 	"os"
@@ -771,7 +772,8 @@ func (engine *Engine) GetAllIds() []uint64 {
 	for i := range engine.dbs {
 		engine.dbs[i].ForEach(func(k, v []byte) error {
 			// fmt.Println(k, v)
-			docsId = append(docsId, uint64(k[0]))
+			docId, _ := binary.Uvarint(k)
+			docsId = append(docsId, docId)
 			return nil
 		})
 	}
@@ -786,7 +788,8 @@ func (engine *Engine) GetAllDocIds() []uint64 {
 	for i := range engine.dbs {
 		engine.dbs[i].ForEach(func(k, v []byte) error {
 			// fmt.Println(k, v)
-			docsId = append(docsId, uint64(k[0]))
+			docId, _ := binary.Uvarint(k)
+			docsId = append(docsId, docId)
 			return nil
 		})
 	}

--- a/engine_test.go
+++ b/engine_test.go
@@ -1053,6 +1053,7 @@ func TestSearchLogic(t *testing.T) {
 }
 
 func TestDocGetAllID(t *testing.T) {
+	gob.Register(ScoringFields{})
 	var engine Engine
 	engine.Init(types.EngineOpts{
 		Using:         1,


### PR DESCRIPTION
fix GetAllDocIds() and GetAllIds() can not get real ids.
- Issues: #37 

**Provide test code:**

    ```Go
        for _, id := range postSearcher.GetAllDocIds() {
		println("ID = %d", id)
	}
    ```
    
fix test code of 

```go

func TestEngineIndexDocWithPersistentStorage(t *testing.T) {
	gob.Register(ScoringFields{}) //  new code
        ....
}
```
## Description

...
