### PR TITLE
fix bbolt import

### DIFF
--- a/riot_pkg.go
+++ b/riot_pkg.go
@@ -20,11 +20,9 @@ Package riot full text search engine
 package riot
 
 import (
-	// _ "github.com/cznic/kv"
-	_ "github.com/coreos/bbolt"
-	// _ "github.com/boltdb/bolt"
 	_ "github.com/dgraph-io/badger"
 	_ "github.com/go-ego/gse"
 	_ "github.com/go-ego/murmur"
 	_ "github.com/syndtr/goleveldb/leveldb"
+	_ "go.etcd.io/bbolt"
 )

--- a/store/bolt_store.go
+++ b/store/bolt_store.go
@@ -17,8 +17,7 @@ package store
 import (
 	"time"
 
-	"github.com/coreos/bbolt"
-	// "github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 var gdocs = []byte("gdocs")


### PR DESCRIPTION
## Description

To make this repo go-gettable. Use `go.etcd.io/bbolt` for importing bbolt.