### PR TITLE
Fix broken link

### DIFF
--- a/docs/en/persistent_storage.md
+++ b/docs/en/persistent_storage.md
@@ -25,7 +25,7 @@ Use persistent storage when UseStore is true:
 
 ### Must pay attention to matters
 
-1. If the sorter uses [custom score field] (/ docs / en / custom_scoring_criteria.md) then that type must be registered in the gob, as in the example on the left which needs to be added before calling engine.Init：
+1. If the sorter uses [custom score field](/docs/en/custom_scoring_criteria.md) then that type must be registered in the gob, as in the example on the left which needs to be added before calling engine.Init：
 ```
 gob.Register(MyScoringFields{})
 ```


### PR DESCRIPTION
## Description
Fixes markdown for one link on persistence page, spaces between `]` and `(` are not allowed.
...
